### PR TITLE
Add Sonoma catalog

### DIFF
--- a/installinstallmacos.py
+++ b/installinstallmacos.py
@@ -90,6 +90,11 @@ DEFAULT_SUCATALOGS = {
         "index-13-12-10.16-10.15-10.14-10.13-10.12-10.11-10.10-10.9"
         "-mountainlion-lion-snowleopard-leopard.merged-1.sucatalog"
     ),
+    "23": (
+        "https://swscan.apple.com/content/catalogs/others/"
+        "index-14-13-12-10.16-10.15-10.14-10.13-10.12-10.11-10.10-10.9"
+        "-mountainlion-lion-snowleopard-leopard.merged-1.sucatalog"
+    ),
 }
 
 SEED_CATALOGS_PLIST = (


### PR DESCRIPTION
I've created a Sonoma image successfully with this change:

```

installinstallmacos.py - get macOS installers from the Apple software catalog

This Mac:
Identified as a Virtual Machine
Model Identifier : Macmini8,1

Board ID         : <<redacted>>
OS Version       : 14.0
Build ID         : 23A344

 #  ProductID       Version    Build    Post Date   Title
/cache/macos-install/macadmin-scripts/./installinstallmacos.py:718: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
  if LegacyVersion(current_item) > LegacyVersion(latest_item):
 1  061-26578       10.14.5    18F2059  2019-10-14  macOS Mojave
 2  061-26589       10.14.6    18G103   2019-10-14  macOS Mojave
 3  041-91758       10.13.6    17G66    2019-10-19  macOS High Sierra
 4  041-88800       10.14.4    18E2034  2019-10-23  macOS Mojave
 5  041-90855       10.13.5    17F66a   2019-10-23  Install macOS High Sierra Beta
 6  061-86291       10.15.3    19D2064  2020-03-23  macOS Catalina
 7  001-04366       10.15.4    19E2269  2020-05-04  macOS Catalina
 8  001-15219       10.15.5    19F2200  2020-06-15  macOS Catalina
 9  001-36735       10.15.6    19G2006  2020-08-06  macOS Catalina
10  001-36801       10.15.6    19G2021  2020-08-12  macOS Catalina
11  001-51042       10.15.7    19H2     2020-09-24  macOS Catalina
12  001-57224       10.15.7    19H4     2020-10-27  macOS Catalina
13  001-68446       10.15.7    19H15    2020-11-11  macOS Catalina
14  042-01917       13.4.1     22F82    2023-06-28  macOS Ventura
15  032-97690       12.6.7     21G651   2023-06-28  macOS Monterey
16  032-96684       11.7.8     20G1351  2023-06-28  macOS Big Sur
17  032-69593       13.5       22G74    2023-07-24  macOS Ventura
18  042-15015       12.6.8     21G725   2023-07-24  macOS Monterey
19  042-14707       11.7.9     20G1426  2023-07-24  macOS Big Sur
20  042-25643       13.5.1     22G90    2023-08-17  macOS Ventura
21  042-43677       13.5.2     22G91    2023-09-07  macOS Ventura
22  042-45268       12.6.9     21G726   2023-09-11  macOS Monterey
23  042-45246       11.7.10    20G1427  2023-09-11  macOS Big Sur
24  042-55926       13.6       22G120   2023-09-21  macOS Ventura
25  042-55586       12.7       21G816   2023-09-21  macOS Monterey
26  042-58988       14.0       23A344   2023-09-26  macOS Sonoma

Choose a product to download (1-26): 26
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 11.9G  100 11.9G    0     0  9958k      0  0:21:00  0:21:00 --:--:-- 9400k
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 1376k  100 1376k    0     0  1813k      0 --:--:-- --:--:-- --:--:-- 1919k
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  5076  100  5076    0     0  30300      0 --:--:-- --:--:-- --:--:-- 38165
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 3606k  100 3606k    0     0  5628k      0 --:--:-- --:--:-- --:--:-- 6000k
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   181  100   181    0     0   1531      0 --:--:-- --:--:-- --:--:--  1740
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 7257k  100 7257k    0     0  8083k      0 --:--:-- --:--:-- --:--:-- 8237k
Making empty sparseimage...
installer: Package name is macOS Sonoma
installer: Installing at base path /private/tmp/dmg.ichqiH
installer: The install was successful.
*********************************************************
*** Working around a very dumb Apple bug in a package ***
*** postinstall script that fails to correctly target ***
*** the Install macOS.app when installed to a volume  ***
*** other than the current boot volume.               ***
***       Please file feedback with Apple!            ***
*********************************************************
Product downloaded and installed to /cache/macos-install/macadmin-scripts/Install_macOS_14.0-23A344.sparseimage
Making read-only compressed disk image containing Install macOS Sonoma.app...
.........................................................2023-10-01 19:36:59.216 hdiutil[3601:27561] -[DIHelperProxy(Thread) waitForHelperDone] timed out waiting for helper registration
..............................................................
created: /cache/macos-install/macadmin-scripts/Install_macOS_14.0-23A344.dmg
Disk image created at: ./Install_macOS_14.0-23A344.dmg
```